### PR TITLE
feat: 分享接收上传与 SystemUI 负载优化

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,23 @@
             android:name=".activity.TransferActivity"
             android:label="@string/activity_transfer" />
 
+        <!-- 分享接收：作为系统分享目标，收到的文本/文件上传到服务器 -->
+        <activity
+            android:name=".activity.ShareActivity"
+            android:exported="true"
+            android:label="@string/share_activity_label">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".activity.MoreActivity"
             android:label="@string/item_more" />

--- a/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/MainActivity.kt
+++ b/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/MainActivity.kt
@@ -8,7 +8,9 @@ import android.content.IntentFilter
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -284,6 +286,24 @@ fun SyncControlsCard(viewModel: MainViewModel) {
     val toast by viewModel.toast.collectAsState()
     val context = LocalContext.current
 
+    // "上传文件"：系统文件选择器 → 选中后交给 ShareActivity 上传（复用上传进度界面）
+    val filePicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            val activity = context as? Activity
+            if (activity == null || activity.isFinishing) return@rememberLauncherForActivityResult
+            val mime = runCatching { context.contentResolver.getType(uri) }.getOrNull()
+            activity.startActivity(
+                Intent(activity, ShareActivity::class.java).apply {
+                    putExtra(ShareActivity.EXTRA_FILE_URI, uri.toString())
+                    putExtra(ShareActivity.EXTRA_FILE_MIME, mime)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+            )
+        }
+    }
+
     LaunchedEffect(toast) {
         toast?.let { msg ->
             android.widget.Toast.makeText(
@@ -305,6 +325,11 @@ fun SyncControlsCard(viewModel: MainViewModel) {
             title = stringResource(R.string.action_upload_now),
             summary = if (isBusy) "..." else stringResource(R.string.main_upload_now_desc),
             onClick = { if (!isBusy) viewModel.uploadNow() }
+        )
+        ArrowPreference(
+            title = stringResource(R.string.action_upload_file),
+            summary = stringResource(R.string.main_upload_file_desc),
+            onClick = { filePicker.launch(arrayOf("*/*")) }
         )
     }
 }

--- a/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/MoreActivity.kt
+++ b/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/MoreActivity.kt
@@ -2,17 +2,29 @@ package io.github.erenche.syncclipboard.app.activity
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.erenche.syncclipboard.app.R
 import io.github.erenche.syncclipboard.app.compose.AppToolBarListContainer
+import io.github.erenche.syncclipboard.bridge.BridgeKeys
+import io.github.erenche.syncclipboard.bridge.SyncClipboardBridge
+import io.github.erenche.syncclipboard.common.PackageNames
 import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.overlay.OverlayDialog
 import top.yukonga.miuix.kmp.preference.ArrowPreference
 
 class MoreActivity : BaseActivity() {
@@ -26,6 +38,7 @@ class MoreActivity : BaseActivity() {
 fun MoreScreen() {
     val context = LocalContext.current
     val activity = context as? android.app.Activity
+    var showCleanupDialog by remember { mutableStateOf(false) }
 
     AppToolBarListContainer(
         title = stringResource(R.string.item_more),
@@ -68,6 +81,20 @@ fun MoreScreen() {
             }
         }
 
+        item("cleanup") {
+            Card(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
+                    .fillMaxWidth()
+            ) {
+                ArrowPreference(
+                    title = stringResource(R.string.item_clean_engine_data),
+                    summary = stringResource(R.string.item_clean_engine_data_summary),
+                    onClick = { showCleanupDialog = true }
+                )
+            }
+        }
+
         item("log") {
             Card(
                 modifier = Modifier
@@ -96,6 +123,42 @@ fun MoreScreen() {
                     onClick = {
                         context.startActivity(Intent(context, AboutActivity::class.java))
                     }
+                )
+            }
+        }
+    }
+
+    if (showCleanupDialog) {
+        OverlayDialog(
+            show = true,
+            title = stringResource(R.string.item_clean_engine_data),
+            summary = stringResource(R.string.clean_engine_data_confirm),
+            onDismissRequest = { showCleanupDialog = false }
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                TextButton(
+                    text = stringResource(R.string.action_cancel),
+                    onClick = { showCleanupDialog = false },
+                    modifier = Modifier.weight(1f)
+                )
+                TextButton(
+                    text = stringResource(R.string.action_confirm),
+                    onClick = {
+                        showCleanupDialog = false
+                        SyncClipboardBridge.with(context)
+                            .to(PackageNames.SYSTEM_UI)
+                            .key(BridgeKeys.CLEAR_ENGINE_DATA)
+                            .send()
+                        Toast.makeText(
+                            context,
+                            R.string.clean_engine_data_done,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    modifier = Modifier.weight(1f)
                 )
             }
         }

--- a/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/ShareActivity.kt
+++ b/app/src/main/kotlin/io/github/erenche/syncclipboard/app/activity/ShareActivity.kt
@@ -1,0 +1,623 @@
+package io.github.erenche.syncclipboard.app.activity
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.OpenableColumns
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import androidx.lifecycle.lifecycleScope
+import io.github.erenche.syncclipboard.app.R
+import io.github.erenche.syncclipboard.app.compose.AppToolBarListContainer
+import io.github.erenche.syncclipboard.bridge.BridgeKeys
+import io.github.erenche.syncclipboard.bridge.SyncClipboardBridge
+import io.github.erenche.syncclipboard.common.PackageNames
+import io.github.erenche.syncclipboard.common.Prefs
+import io.github.erenche.syncclipboard.common.model.ClipboardContent
+import io.github.erenche.syncclipboard.common.model.ClipboardContentType
+import io.github.erenche.syncclipboard.common.util.Logger
+import io.github.erenche.syncclipboard.xposed.api.ClientFactory
+import io.github.erenche.syncclipboard.xposed.api.SyncClipboardApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import top.yukonga.miuix.kmp.basic.ButtonDefaults
+import top.yukonga.miuix.kmp.basic.Card
+import top.yukonga.miuix.kmp.basic.LinearProgressIndicator
+import top.yukonga.miuix.kmp.basic.Text
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.theme.MiuixTheme
+import java.io.File
+import java.util.Locale
+import java.util.UUID
+import kotlin.math.roundToInt
+
+/**
+ * 分享接收页 — 作为系统分享目标，把收到的文本/文件上传到服务器。
+ *
+ * 文本：走 UPLOAD_TEXT 桥接（引擎同时复制到剪贴板），Toast 提示后自动关闭。
+ * 文件：复制到 App 私有 cacheDir 后**由 App 进程直接上传**（不再经 SystemUI，
+ * 因此不受 SystemUI 重启/进程回收影响），进度在本地 StateFlow 实时驱动 UI；
+ * 上传成功后通过 REGISTER_UPLOADED 通知引擎登记历史并更新远端缓存。
+ *
+ * 界面：MIUIX Card + LinearProgressIndicator，每文件独立进度条/速度/状态。
+ */
+class ShareActivity : BaseActivity() {
+
+    /** 单个分享项的上传状态 */
+    enum class ItemState { WAITING, UPLOADING, SUCCESS, FAILED }
+
+    /** 单个分享文件的可变状态（由本地上传协程驱动） */
+    data class ShareItem(
+        val transferId: String,
+        val fileName: String,
+        val fileSize: Long,
+        val isImage: Boolean,
+        val state: ItemState = ItemState.WAITING,
+        val progress: Float = 0f,
+        val sent: Long = 0L,
+        val total: Long = 0L,
+        val speed: Long = 0L,
+        val error: String? = null,
+    )
+
+    /** 分享页整体状态 */
+    data class ShareUiState(
+        val items: List<ShareItem> = emptyList(),
+        /** 全部文件已出结果（成功+失败），延时自动关闭 */
+        val finished: Boolean = false,
+    )
+
+    private data class SpeedSample(val bytes: Long, val time: Long)
+
+    /** 距上次进度事件的采样点，用于估算实时速度 */
+    private val speedSamples = mutableStateMapOf<String, SpeedSample>()
+
+    private val _uiState = MutableStateFlow(ShareUiState())
+    private val uiState: StateFlow<ShareUiState> = _uiState.asStateFlow()
+
+    /** 等待结果期间的本地缓存文件（transferId → File）；失败立即清理，成功后交给过期兜底 */
+    private val pendingFiles = mutableMapOf<String, File>()
+    private var isFinishing = false
+
+    // ─── 生命周期 ──────────────────────────────────────────────
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ShareScreen(uiState.collectAsState().value, onFinish = { finish() })
+        }
+        handleShare(intent)
+    }
+
+    override fun onDestroy() {
+        cleanupPendingFiles()
+        super.onDestroy()
+    }
+
+    // ─── 分享分发 ──────────────────────────────────────────────
+
+    private fun handleShare(intent: Intent?) {
+        // 主页"上传文件"入口：显式传入 content:// URI（已授权读取），不需要走系统分享 Intent
+        val explicitUri = intent?.getStringExtra(EXTRA_FILE_URI)
+        if (!explicitUri.isNullOrBlank()) {
+            handleFileShare(listOf(Uri.parse(explicitUri)), intent.getStringExtra(EXTRA_FILE_MIME))
+            return
+        }
+        when (intent?.action) {
+            Intent.ACTION_SEND -> {
+                val stream = parcelableStream(intent)
+                if (stream != null) {
+                    handleFileShare(listOf(stream), intent.type)
+                } else {
+                    handleTextShare(intent)
+                }
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                val streams = parcelableStreamList(intent)
+                if (streams.isNotEmpty()) {
+                    handleFileShare(streams, intent.type)
+                } else {
+                    handleTextShare(intent)
+                }
+            }
+            else -> {
+                Toast.makeText(this, R.string.share_empty, Toast.LENGTH_SHORT).show()
+                finishAfterDelay(600)
+            }
+        }
+    }
+
+    /** 文本分享：直接走 UPLOAD_TEXT（引擎会同时复制到剪贴板），提示后关闭 */
+    private fun handleTextShare(intent: Intent) {
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+        if (text.isNullOrBlank()) {
+            Toast.makeText(this, R.string.share_empty, Toast.LENGTH_SHORT).show()
+            finishAfterDelay(600)
+            return
+        }
+        Toast.makeText(this, R.string.share_text_uploading, Toast.LENGTH_SHORT).show()
+        SyncClipboardBridge.with(this)
+            .to(PackageNames.SYSTEM_UI)
+            .key(BridgeKeys.UPLOAD_TEXT)
+            .payload(Bundle().apply { putString("text", text) })
+            .send()
+        finishAfterDelay(800)
+    }
+
+    /** 文件分享：复制到 cacheDir → App 进程直接上传（进度本地驱动，不依赖 SystemUI 存续） */
+    private fun handleFileShare(uris: List<Uri>, intentType: String?) {
+        lifecycleScope.launch {
+            // 清理超过 1 小时的历史残留文件
+            withContext(Dispatchers.IO) { cleanupStaleFiles() }
+
+            data class Prepared(val localFile: File, val displayName: String, val isImage: Boolean)
+
+            val prepared = mutableListOf<Prepared>()
+            for (uri in uris) {
+                val display = sanitizeFileName(queryDisplayName(uri) ?: "share_${System.currentTimeMillis()}")
+                val localFile = withContext(Dispatchers.IO) { copyToCache(uri, display) }
+                if (localFile != null) {
+                    prepared.add(Prepared(localFile, display, isImageUri(uri, intentType)))
+                } else {
+                    Logger.warn(TAG, "ShareActivity: failed to copy $uri")
+                }
+            }
+
+            if (prepared.isEmpty()) {
+                Toast.makeText(this@ShareActivity, R.string.share_empty, Toast.LENGTH_SHORT).show()
+                finishAfterDelay(800)
+                return@launch
+            }
+
+            // 服务器配置（与引擎一致：以 app 侧 prefs 为准）
+            val config = Prefs.loadConfig(this@ShareActivity)
+            val server = config.servers.getOrNull(config.activeServerIndex)
+            val api = server?.let { runCatching { ClientFactory.createClient(it) }.getOrNull() }
+            if (api == null) {
+                Toast.makeText(this@ShareActivity, R.string.share_no_server, Toast.LENGTH_SHORT).show()
+                finishAfterDelay(1200)
+                return@launch
+            }
+
+            val items = prepared.map { p ->
+                ShareItem(
+                    transferId = UUID.randomUUID().toString(),
+                    fileName = p.displayName,
+                    fileSize = p.localFile.length(),
+                    isImage = p.isImage,
+                )
+            }
+            _uiState.value = ShareUiState(items = items)
+            prepared.zip(items).forEach { (p, item) ->
+                pendingFiles[item.transferId] = p.localFile
+            }
+            // 逐文件串行上传，进度实时更新本地状态
+            prepared.zip(items).forEach { (p, item) ->
+                uploadFile(api, item, p.localFile)
+            }
+        }
+    }
+
+    /** 单个文件上传：App 进程直接调用服务器 API，成功/失败同步更新 UI */
+    private suspend fun uploadFile(api: SyncClipboardApi, item: ShareItem, file: File) {
+        updateItem(item.transferId) { it.copy(state = ItemState.UPLOADING, progress = 0f) }
+        val content = ClipboardContent(
+            type = if (item.isImage) ClipboardContentType.Image else ClipboardContentType.File,
+            text = item.fileName,
+            fileUri = file.absolutePath,
+            fileName = item.fileName,
+            fileSize = item.fileSize.takeIf { it > 0 },
+            hasData = true,
+            timestamp = System.currentTimeMillis()
+        )
+        var error: String? = null
+        val ok = try {
+            withTimeoutOrNull(UPLOAD_TIMEOUT_MS) {
+                api.putContent(content) { sent, total ->
+                    val speed = estimateSpeed(item.transferId, sent)
+                    val progress = if (total > 0) (sent.toFloat() / total).coerceIn(0f, 1f) else 0f
+                    updateItem(item.transferId) {
+                        it.copy(progress = progress, sent = sent, total = total, speed = speed)
+                    }
+                }
+                true
+            } == true
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // 协程取消（页面销毁）：继续传播，不当作上传失败
+            throw e
+        } catch (e: Exception) {
+            // 网络异常等：标记失败而非让协程崩溃
+            Logger.error(TAG, "uploadFile failed: ${e.message}", e)
+            error = e.message
+            false
+        }
+        if (!ok && error == null) error = getString(R.string.share_timeout)
+
+        if (ok) {
+            updateItem(item.transferId) { it.copy(state = ItemState.SUCCESS, progress = 1f) }
+            notifyEngineRegistered(item, file)
+        } else {
+            updateItem(item.transferId) { it.copy(state = ItemState.FAILED, error = error) }
+            // 失败文件立即清理（成功文件留给引擎登记 + 1 小时过期兜底）
+            pendingFiles.remove(item.transferId)?.takeIf { it.exists() }?.delete()
+        }
+        maybeFinish()
+    }
+
+    /** 上传成功后通知引擎：登记历史 + 更新远端缓存（避免轮询误判重复下载） */
+    private fun notifyEngineRegistered(item: ShareItem, file: File) {
+        try {
+            val providerUri = FileProvider.getUriForFile(
+                this, "$packageName.fileprovider", file
+            )
+            grantUriPermission(PackageNames.SYSTEM_UI, providerUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            SyncClipboardBridge.with(this)
+                .to(PackageNames.SYSTEM_UI)
+                .key(BridgeKeys.REGISTER_UPLOADED)
+                .payload(Bundle().apply {
+                    putString("fileUri", providerUri.toString())
+                    putString("fileName", item.fileName)
+                    putBoolean("isImage", item.isImage)
+                    putLong("fileSize", item.fileSize)
+                })
+                .send()
+            Logger.info(TAG, "notifyEngineRegistered name=${item.fileName}, size=${item.fileSize}")
+        } catch (e: Exception) {
+            Logger.warn(TAG, "notifyEngineRegistered failed: ${e.message}")
+        }
+    }
+
+    // ─── 状态更新 ──────────────────────────────────────────────
+
+    private fun updateItem(transferId: String, transform: (ShareItem) -> ShareItem) {
+        _uiState.update { s ->
+            if (s.items.any { it.transferId == transferId }) {
+                s.copy(items = s.items.map { if (it.transferId == transferId) transform(it) else it })
+            } else {
+                s
+            }
+        }
+    }
+
+    /** 估算上传速度（bytes/s）：用距上次进度事件的字节差/时间差 */
+    private fun estimateSpeed(transferId: String, sent: Long): Long {
+        val now = android.os.SystemClock.elapsedRealtime()
+        val prev = speedSamples[transferId]
+        val speed = if (prev != null && sent > prev.bytes && now > prev.time) {
+            ((sent - prev.bytes) * 1000L) / (now - prev.time)
+        } else 0L
+        speedSamples[transferId] = SpeedSample(sent, now)
+        return speed
+    }
+
+    /** 所有文件都有结果后：标记完成并延时关闭 */
+    private fun maybeFinish() {
+        val s = _uiState.value
+        if (s.items.isEmpty() || s.finished) return
+        val allDone = s.items.all { it.state == ItemState.SUCCESS || it.state == ItemState.FAILED }
+        if (allDone) {
+            _uiState.update { it.copy(finished = true) }
+            finishAfterDelay(1200)
+        }
+    }
+
+    // ─── 工具方法 ──────────────────────────────────────────────
+
+    @Suppress("DEPRECATION")
+    private fun parcelableStream(intent: Intent): Uri? =
+        intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+
+    @Suppress("DEPRECATION")
+    private fun parcelableStreamList(intent: Intent): List<Uri> {
+        val list = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM) ?: return emptyList()
+        return list.filterNotNull()
+    }
+
+    private fun queryDisplayName(uri: Uri): String? = try {
+        contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+            ?: uri.lastPathSegment
+    } catch (e: Exception) {
+        Logger.warn(TAG, "queryDisplayName failed: ${e.message}")
+        uri.lastPathSegment
+    }
+
+    /** 文件名清理：去路径分隔符与非法字符，限制长度 */
+    private fun sanitizeFileName(name: String): String {
+        val cleaned = name.substringAfterLast('/').substringAfterLast('\\')
+            .replace(Regex("[\\\\/:*?\"<>|\\u0000]"), "_")
+            .trim()
+            .take(120)
+        return cleaned.ifBlank { "share_${System.currentTimeMillis()}" }
+    }
+
+    private fun copyToCache(uri: Uri, displayName: String): File? {
+        return try {
+            val dir = File(cacheDir, "share").apply { mkdirs() }
+            val dest = File(dir, "${System.currentTimeMillis()}_$displayName")
+            contentResolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
+            dest
+        } catch (e: Exception) {
+            Logger.error(TAG, "copyToCache failed: ${e.message}", e)
+            null
+        }
+    }
+
+    private fun isImageUri(uri: Uri, intentType: String?): Boolean {
+        if (intentType?.startsWith("image/") == true) return true
+        return try {
+            contentResolver.getType(uri)?.startsWith("image/") == true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /** 清理 cacheDir/share 下超过 1 小时的残留文件（成功上传的文件也由这里兜底清理） */
+    private fun cleanupStaleFiles() {
+        try {
+            val dir = File(cacheDir, "share")
+            if (!dir.isDirectory) return
+            val cutoff = System.currentTimeMillis() - 3_600_000L
+            dir.listFiles()?.forEach { file ->
+                if (file.isFile && file.lastModified() < cutoff) file.delete()
+            }
+        } catch (_: Exception) {}
+    }
+
+    /** 页面销毁时清理尚未成功上传的缓存文件（成功文件保留给引擎登记，由过期清理兜底） */
+    private fun cleanupPendingFiles() {
+        val successIds = _uiState.value.items
+            .filter { it.state == ItemState.SUCCESS }
+            .map { it.transferId }
+            .toSet()
+        val files = pendingFiles.filterKeys { it !in successIds }.values.toList()
+        pendingFiles.clear()
+        if (files.isEmpty()) return
+        Thread {
+            files.forEach { runCatching { it.delete() } }
+        }.start()
+    }
+
+    private fun finishAfterDelay(delayMs: Long = 1200) {
+        if (isFinishing) return
+        isFinishing = true
+        lifecycleScope.launch {
+            delay(delayMs)
+            finish()
+        }
+    }
+
+    companion object {
+        const val TAG = "ShareActivity"
+        /** 单个文件上传超时（毫秒） */
+        const val UPLOAD_TIMEOUT_MS = 5 * 60_000L
+
+        /** 主页"上传文件"入口：显式传入的待上传文件 URI（content://，调用方已授权读取） */
+        const val EXTRA_FILE_URI = "extra_file_uri"
+
+        /** 显式传入 URI 时的 MIME 类型（用于图片/文件判定，可为 null） */
+        const val EXTRA_FILE_MIME = "extra_file_mime"
+    }
+}
+
+/** 文件大小格式化：B / KB / MB / GB */
+private fun formatBytes(bytes: Long): String {
+    if (bytes <= 0) return "0 B"
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return String.format(Locale.US, "%.1f KB", kb)
+    val mb = kb / 1024.0
+    if (mb < 1024) return String.format(Locale.US, "%.1f MB", mb)
+    return String.format(Locale.US, "%.2f GB", mb / 1024.0)
+}
+
+// ─── 界面 ─────────────────────────────────────────────────────
+
+@Composable
+private fun ShareScreen(state: ShareActivity.ShareUiState, onFinish: () -> Unit) {
+    val doneCount = state.items.count { it.state == ShareActivity.ItemState.SUCCESS }
+    val failedCount = state.items.count { it.state == ShareActivity.ItemState.FAILED }
+    val total = state.items.size
+
+    AppToolBarListContainer(
+        title = stringResource(R.string.share_title),
+        canBack = true,
+        onBack = onFinish,
+        actions = {
+            if (state.finished) {
+                TextButton(
+                    text = stringResource(R.string.share_finish),
+                    onClick = onFinish,
+                    colors = ButtonDefaults.textButtonColorsPrimary(),
+                    minHeight = 36.dp,
+                    minWidth = 0.dp,
+                    insideMargin = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+                )
+            }
+        }
+    ) {
+        if (state.items.isEmpty()) {
+            item("empty") {
+                Card(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 24.dp)
+                        .fillMaxWidth()
+                ) {
+                    Text(
+                        text = stringResource(R.string.share_empty),
+                        style = MiuixTheme.textStyles.body1,
+                        color = MiuixTheme.colorScheme.onBackgroundVariant,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+            }
+        } else {
+            item("summary") {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 2.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = if (state.finished) {
+                            stringResource(R.string.share_status_done, doneCount, failedCount)
+                        } else {
+                            stringResource(R.string.share_status_uploading, doneCount + failedCount, total)
+                        },
+                        style = MiuixTheme.textStyles.body2,
+                        color = if (state.finished) MiuixTheme.colorScheme.primary
+                        else MiuixTheme.colorScheme.onBackgroundVariant,
+                    )
+                }
+            }
+            state.items.forEach { shareItem ->
+                item(shareItem.transferId) {
+                    ShareItemCard(shareItem)
+                }
+            }
+        }
+        item("footer") { Spacer(modifier = Modifier.height(16.dp)) }
+    }
+}
+
+/** 单个分享文件卡片：文件名 + 类型 + 大小/速度 + 实时进度条 + 状态 */
+@Composable
+private fun ShareItemCard(item: ShareActivity.ShareItem) {
+    // 进度值事件间平滑过渡，避免分段跳变看着生硬
+    val animatedProgress by animateFloatAsState(
+        targetValue = item.progress,
+        animationSpec = tween(150),
+        label = "share-progress",
+    )
+    Card(
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .fillMaxWidth(),
+        insideMargin = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // 第一行：类型标签 + 文件名 + 状态
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(if (item.isImage) R.string.type_image else R.string.type_file),
+                    style = MiuixTheme.textStyles.body2,
+                    color = MiuixTheme.colorScheme.primary,
+                )
+                Text(
+                    text = item.fileName,
+                    style = MiuixTheme.textStyles.body1,
+                    color = MiuixTheme.colorScheme.onBackground,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp),
+                )
+                Text(
+                    text = when (item.state) {
+                        ShareActivity.ItemState.WAITING -> stringResource(R.string.share_waiting)
+                        ShareActivity.ItemState.UPLOADING ->
+                            stringResource(R.string.transfer_progress, (item.progress * 100).roundToInt())
+                        ShareActivity.ItemState.SUCCESS -> stringResource(R.string.share_done)
+                        ShareActivity.ItemState.FAILED -> stringResource(R.string.share_failed)
+                    },
+                    style = MiuixTheme.textStyles.body2,
+                    color = shareStatusColor(item.state),
+                )
+            }
+
+            // 第二行：文件大小 + 实时速度
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = formatBytes(item.fileSize),
+                    style = MiuixTheme.textStyles.body2,
+                    color = MiuixTheme.colorScheme.onBackgroundVariant,
+                )
+                if (item.state == ShareActivity.ItemState.UPLOADING && item.speed > 0L) {
+                    Text(
+                        text = "${formatBytes(item.speed)}/s",
+                        style = MiuixTheme.textStyles.body2,
+                        color = MiuixTheme.colorScheme.onBackgroundVariant,
+                    )
+                }
+            }
+
+            // 第三行：进度条 / 状态明细
+            when (item.state) {
+                ShareActivity.ItemState.WAITING -> Unit
+
+                ShareActivity.ItemState.UPLOADING -> {
+                    LinearProgressIndicator(
+                        progress = if (animatedProgress > 0f) animatedProgress else null,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                ShareActivity.ItemState.SUCCESS -> {
+                    LinearProgressIndicator(
+                        progress = if (animatedProgress > 0f) animatedProgress else null,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+
+                ShareActivity.ItemState.FAILED -> {
+                    val err = item.error
+                    if (!err.isNullOrBlank()) {
+                        Text(
+                            text = err,
+                            style = MiuixTheme.textStyles.body2,
+                            color = MiuixTheme.colorScheme.error,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun shareStatusColor(state: ShareActivity.ItemState): Color {
+    return when (state) {
+        ShareActivity.ItemState.SUCCESS -> MiuixTheme.colorScheme.primary
+        ShareActivity.ItemState.FAILED -> MiuixTheme.colorScheme.error
+        ShareActivity.ItemState.UPLOADING -> MiuixTheme.colorScheme.primary
+        ShareActivity.ItemState.WAITING -> MiuixTheme.colorScheme.onBackgroundVariant
+    }
+}

--- a/app/src/main/kotlin/io/github/erenche/syncclipboard/app/viewmodel/MainViewModel.kt
+++ b/app/src/main/kotlin/io/github/erenche/syncclipboard/app/viewmodel/MainViewModel.kt
@@ -234,8 +234,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    /** 通过 ServerApi 下载远程文件到 app cacheDir，按 hash 缓存文件名 */
-    private fun downloadRemoteFile(profile: ProfileDto): File? {
+    /** 通过 ServerApi 下载远程文件到 app cacheDir，按 hash 缓存文件名。
+     *  优先从引擎下载目录获取（引擎已下载过则免走网络），未命中再走网络。 */
+    private suspend fun downloadRemoteFile(profile: ProfileDto): File? {
         return try {
             val config = io.github.erenche.syncclipboard.common.Prefs.loadConfig(app)
             val server = config.servers.getOrNull(config.activeServerIndex)
@@ -252,6 +253,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 Logger.info("MainViewModel", "Reusing cached remote file: ${destFile.name}")
                 return destFile
             }
+            // 引擎已下载过该文件：直接取字节写入本地，省一次网络下载（限 2MB）
+            val engineBytes = fetchEngineDownloadedFile(profile.dataName!!)
+            if (engineBytes != null) {
+                destFile.writeBytes(engineBytes)
+                Logger.info("MainViewModel", "Reused engine-downloaded file: ${destFile.name}, size=${engineBytes.size}")
+                return destFile
+            }
             val api = ServerApi(server)
             val result = when (server.type) {
                 ServerType.s3 -> api.downloadFileS3(profile.dataName!!, destFile)
@@ -263,8 +271,26 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 Logger.warn("MainViewModel", "Failed to download remote file: ${profile.dataName}")
             }
             result
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             Logger.error("MainViewModel", "downloadRemoteFile error: ${e.message}", e)
+            null
+        }
+    }
+
+    /** 向引擎查询已下载的文件字节（≤2MB），未命中返回 null */
+    private suspend fun fetchEngineDownloadedFile(fileName: String): ByteArray? {
+        return try {
+            val bundle = SyncClipboardBridge.with(app)
+                .to("com.android.systemui")
+                .key(BridgeKeys.GET_DOWNLOADED_FILE)
+                .payload(android.os.Bundle().apply { putString("fileName", fileName) })
+                .await(timeout = 4000)
+            val bytes = bundle.getByteArray("bytes")
+            if (bytes != null && bytes.isNotEmpty()) bytes else null
+        } catch (e: Exception) {
+            Logger.debug("MainViewModel", "fetchEngineDownloadedFile miss: ${e.message}")
             null
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_restart">重启</string>
     <string name="action_sync_now">立即同步</string>
     <string name="action_upload_now">立即上传</string>
+    <string name="action_upload_file">上传文件</string>
+    <string name="main_upload_file_desc">从本地选择文件上传到服务器</string>
     <string name="action_test_connection">测试连接</string>
     <string name="action_cancel">取消</string>
     <string name="action_save">保存</string>
@@ -162,6 +164,10 @@
     <string name="item_history_summary">查看已同步的剪贴板历史</string>
     <string name="item_log">日志</string>
     <string name="item_log_summary">查看同步引擎运行日志</string>
+    <string name="item_clean_engine_data">清理引擎数据</string>
+    <string name="item_clean_engine_data_summary">删除引擎侧历史、下载文件与临时文件</string>
+    <string name="clean_engine_data_confirm">将删除引擎侧所有数据（历史记录、下载文件、临时文件），不影响服务器上的数据。确定继续吗？</string>
+    <string name="clean_engine_data_done">引擎数据已清理</string>
     <string name="log_level_debug">调试</string>
     <string name="log_level_info">信息</string>
     <string name="log_level_warn">警告</string>
@@ -215,6 +221,21 @@
     <string name="history_selected_count">已选 %d 项</string>
     <string name="history_delete_selected">删除 (%d)</string>
     <string name="activity_transfer">传输队列</string>
+
+    <!-- 分享接收 -->
+    <string name="share_activity_label">上传到 SyncClipboard</string>
+    <string name="share_title">接收分享</string>
+    <string name="share_status_uploading">正在上传 %1$d/%2$d …</string>
+    <string name="share_status_done">上传完成（成功 %1$d，失败 %2$d）</string>
+    <string name="share_text_uploading">正在上传文本…</string>
+    <string name="share_empty">未找到可上传的内容</string>
+    <string name="share_timeout">上传超时，请检查网络和服务器设置</string>
+    <string name="share_waiting">等待中</string>
+    <string name="share_uploading">上传中</string>
+    <string name="share_done">已上传</string>
+    <string name="share_failed">上传失败</string>
+    <string name="share_finish">完成</string>
+    <string name="share_no_server">未配置服务器，请先添加同步服务器</string>
     <string name="transfer_empty">暂无传输任务</string>
     <string name="transfer_summary">进行中 %1$d / 共 %2$d</string>
     <string name="transfer_waiting">等待下载</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_restart">Restart</string>
     <string name="action_sync_now">Sync Now</string>
     <string name="action_upload_now">Upload Now</string>
+    <string name="action_upload_file">Upload File</string>
+    <string name="main_upload_file_desc">Pick a file from device and upload</string>
     <string name="action_test_connection">Test Connection</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_save">Save</string>
@@ -162,6 +164,10 @@
     <string name="item_history_summary">View synced clipboard history</string>
     <string name="item_log">Logs</string>
     <string name="item_log_summary">View sync engine logs</string>
+    <string name="item_clean_engine_data">Clean Engine Data</string>
+    <string name="item_clean_engine_data_summary">Delete engine-side history, downloads and cache</string>
+    <string name="clean_engine_data_confirm">This will delete all engine-side data (history, downloaded files, temp files). The server data is not affected. Continue?</string>
+    <string name="clean_engine_data_done">Engine data cleaned</string>
     <string name="log_level_debug">Debug</string>
     <string name="log_level_info">Info</string>
     <string name="log_level_warn">Warn</string>
@@ -217,6 +223,21 @@
     <string name="history_selected_count">%d selected</string>
     <string name="history_delete_selected">Delete (%d)</string>
     <string name="activity_transfer">Transfers</string>
+
+    <!-- 分享接收 -->
+    <string name="share_activity_label">Upload to SyncClipboard</string>
+    <string name="share_title">Receiving Share</string>
+    <string name="share_status_uploading">Uploading %1$d/%2$d …</string>
+    <string name="share_status_done">Done (%1$d ok, %2$d failed)</string>
+    <string name="share_text_uploading">Uploading text…</string>
+    <string name="share_empty">No uploadable content found</string>
+    <string name="share_timeout">Upload timed out. Please check the network and server settings</string>
+    <string name="share_waiting">Waiting</string>
+    <string name="share_uploading">Uploading</string>
+    <string name="share_done">Uploaded</string>
+    <string name="share_failed">Failed</string>
+    <string name="share_finish">Done</string>
+    <string name="share_no_server">No server configured. Please configure a sync server first</string>
     <string name="transfer_empty">No downloads in queue</string>
     <string name="transfer_summary">%1$d active / %2$d total</string>
     <string name="transfer_waiting">Waiting</string>

--- a/bridge/src/main/kotlin/io/github/erenche/syncclipboard/bridge/BridgeKeys.kt
+++ b/bridge/src/main/kotlin/io/github/erenche/syncclipboard/bridge/BridgeKeys.kt
@@ -88,7 +88,7 @@ object BridgeKeys {
     /** 手动操作结果反馈事件（同步/上传） */
     const val EVENT_ACTION_RESULT = "event_action_result"
 
-    /** 传输进度事件 */
+    /** 传输进度事件（保留兼容；分享上传已改由 App 进程直接上报，不再使用） */
     const val EVENT_TRANSFER_PROGRESS = "event_transfer_progress"
 
     /** 历史同步完成事件（异步通知，syncHistory 完成后推送） */
@@ -100,7 +100,23 @@ object BridgeKeys {
     /** 清空日志缓冲区 */
     const val CLEAR_LOGS = "clear_logs"
 
-    // ─── 文本直传（app → xposed 进程）────────────────────────
+    // ─── 文本直传（app → xposed 进程）──────────────────────────
     /** 直接上传一段文本（如短信验证码）到服务器 */
     const val UPLOAD_TEXT = "upload_text"
+
+    /**
+     * App 进程上传文件成功后向引擎登记（分享/主页"上传文件"）。
+     * payload: fileUri（app FileProvider 的 content:// URI，已授权 SystemUI 读取）、
+     * fileName、isImage、fileSize。
+     * 引擎据此写入历史记录、更新远端缓存（避免轮询误判重复下载）。
+     */
+    const val REGISTER_UPLOADED = "register_uploaded"
+
+    // ─── 引擎数据管理（app → xposed 进程）──────────────────────
+    /** 清理引擎本地数据（历史库/历史文件/下载目录/上传临时文件） */
+    const val CLEAR_ENGINE_DATA = "clear_engine_data"
+
+    /** 查询引擎已下载的文件（避免 app 重复走网络下载）。
+     *  payload: fileName；返回 bytes（byte[]，≤2MB）+ size，无则空 Bundle */
+    const val GET_DOWNLOADED_FILE = "get_downloaded_file"
 }

--- a/common/src/main/kotlin/io/github/erenche/syncclipboard/common/util/HashUtils.kt
+++ b/common/src/main/kotlin/io/github/erenche/syncclipboard/common/util/HashUtils.kt
@@ -17,6 +17,20 @@ object HashUtils {
         return hashBytes.joinToString("") { "%02x".format(it) }
     }
 
+    /** 流式计算 InputStream 的 SHA-256（64KB 分块，不整块读入内存），小写十六进制 */
+    fun sha256(input: java.io.InputStream): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(64 * 1024)
+        input.use { stream ->
+            while (true) {
+                val n = stream.read(buffer)
+                if (n < 0) break
+                digest.update(buffer, 0, n)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
     /** 计算字节数组的 SHA-256（小写十六进制） */
     fun sha256(data: ByteArray): String {
         val digest = MessageDigest.getInstance("SHA-256")
@@ -32,8 +46,16 @@ object HashUtils {
      *   Combined    = "文件名|" + UPPERCASE(ContentHash)
      *   Hash        = SHA256(UTF-8(Combined))
      */
-    fun computeFileHash(fileName: String, fileBytes: ByteArray): String {
-        val contentHash = sha256(fileBytes).uppercase()
+    fun computeFileHash(fileName: String, fileBytes: ByteArray): String =
+        computeFileHash(fileName, fileBytes.inputStream())
+
+    /** 文件版本（分块流式计算，大文件不整块读入内存） */
+    fun computeFileHash(fileName: String, file: File): String =
+        computeFileHash(fileName, file.inputStream())
+
+    /** 输入流版本（分块流式计算，调用方负责流的生命周期） */
+    fun computeFileHash(fileName: String, input: java.io.InputStream): String {
+        val contentHash = sha256(input).uppercase()
         val combined = "$fileName|$contentHash"
         return sha256(combined)
     }
@@ -42,11 +64,11 @@ object HashUtils {
      * 根据 ClipboardContent 计算 profileHash（文件路径必须可读）。
      *
      * - Text → SHA256(text)
-     * - Image/File（绝对路径）→ computeFileHash(fileName, fileBytes)
+     * - Image/File（绝对路径）→ computeFileHash(fileName, file)（分块流式，无内存尖峰）
      * - Image/File（无法读取文件）→ 降级为 SHA256(text)（通常为空字符串，仅作占位）
      *
      * 注意：content:// URI 需要 ContentResolver，无法在此处直接读取；
-     * 调用方（HistoryService）负责预先将 URI 转换为字节数组再调用 computeFileHash。
+     * 调用方（HistoryService）负责预先将 URI 转换为输入流再调用 computeFileHash。
      */
     fun computeContentHash(content: ClipboardContent): String {
         if (content.type != ClipboardContentType.Text &&
@@ -56,7 +78,7 @@ object HashUtils {
         ) {
             return try {
                 val file = File(content.fileUri!!)
-                if (file.exists()) computeFileHash(content.fileName!!, file.readBytes())
+                if (file.exists()) computeFileHash(content.fileName!!, file)
                 else sha256(content.text)
             } catch (_: Exception) {
                 sha256(content.text)

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/CountingFileContent.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/CountingFileContent.kt
@@ -1,0 +1,62 @@
+package io.github.erenche.syncclipboard.xposed.api
+
+import io.ktor.http.ContentType
+import io.ktor.http.content.OutgoingContent
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+import kotlinx.io.buffered
+import java.io.File
+
+/**
+ * 分块流式上传文件内容：按 [CHUNK_SIZE] 读取文件写入请求体，每写出一个块即回调进度。
+ *
+ * 背景：直接 `setBody(file.readBytes())` 时，Ktor 的 onUpload（BodyProgress）对 OkHttp
+ * 引擎只会在整块内容写入完成时回调一次，导致进度条 0 → 100 直接跳变。
+ * 这里在数据源（RawSource）层分块计数，字节被引擎实际拉取时逐块回调，
+ * 配合引擎侧的字节步进节流，UI 进度条能真实分段推进。
+ */
+internal class CountingFileContent(
+    private val file: File,
+    private val mediaType: ContentType?,
+    private val onProgress: (Long) -> Unit
+) : OutgoingContent.ReadChannelContent() {
+
+    override val contentLength: Long get() = file.length()
+
+    override val contentType: ContentType? get() = mediaType
+
+    override fun readFrom(): ByteReadChannel {
+        val source = object : RawSource {
+            private val input = file.inputStream().buffered()
+            private val buffer = ByteArray(CHUNK_SIZE)
+            private var sent = 0L
+            private var eof = false
+
+            override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
+                if (eof) return -1L
+                if (byteCount <= 0L) return 0L
+                val toRead = minOf(byteCount, CHUNK_SIZE.toLong()).toInt()
+                val n = input.read(buffer, 0, toRead)
+                if (n <= 0) {
+                    eof = true
+                    return -1L
+                }
+                sink.write(buffer, startIndex = 0, endIndex = n)
+                sent += n
+                onProgress(sent)
+                return n.toLong()
+            }
+
+            override fun close() {
+                eof = true
+                input.close()
+            }
+        }
+        return ByteReadChannel(source.buffered())
+    }
+
+    private companion object {
+        const val CHUNK_SIZE = 64 * 1024
+    }
+}

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/S3Client.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/S3Client.kt
@@ -104,7 +104,7 @@ class S3Client(
         method: HttpMethod,
         objectKey: String,
         queryString: String = "",
-        body: ByteArray? = null,
+        body: Any? = null,
         contentType: String? = null
     ): HttpResponse {
         // 构建完整对象 key（含 prefix）
@@ -289,25 +289,32 @@ class S3Client(
         return destinationPath
     }
 
-    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Float) -> Unit)?) {
+    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Long, Long) -> Unit)?) {
         val file = File(filePath)
         if (!file.exists()) throw IllegalStateException("File not found: $filePath")
 
+        // 分块流式上传：按块读取并上报真实字节进度
+        val total = file.length()
+        val body = CountingFileContent(file, null) { sent ->
+            onProgress?.invoke(sent, total)
+        }
+        onProgress?.invoke(0L, total)
         val response = sendSignedRequest(
             method = HttpMethod.Put,
             objectKey = "$FILE_FOLDER/$fileName",
-            body = file.readBytes()
+            body = body
         )
         if (!response.status.isSuccess()) {
             val errBody = try { response.bodyAsText() } catch (_: Exception) { "" }
             throw IllegalStateException("S3 putFile failed: ${response.status.value} $errBody")
         }
+        onProgress?.invoke(total, total)
         Logger.info(TAG, "File uploaded to S3: $fileName")
     }
 
-    override suspend fun putContent(content: ClipboardContent) {
+    override suspend fun putContent(content: ClipboardContent, onProgress: ((Long, Long) -> Unit)?) {
         if (content.hasData && content.fileUri != null && content.fileName != null) {
-            putFile(content.fileName!!, content.fileUri!!)
+            putFile(content.fileName!!, content.fileUri!!, onProgress)
         }
 
         val profile = ProfileDto(

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/SyncClipboardApi.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/SyncClipboardApi.kt
@@ -26,13 +26,15 @@ interface SyncClipboardApi {
     /** 下载文件到指定路径 */
     suspend fun downloadFile(fileName: String, destinationPath: String, onProgress: ((Float) -> Unit)? = null): String
 
-    /** 上传文件 */
-    suspend fun putFile(fileName: String, filePath: String, onProgress: ((Float) -> Unit)? = null)
+    /** 上传文件。
+     *  @param onProgress 字节级上传进度回调（sentBytes, totalBytes），totalBytes 未知时为 0 */
+    suspend fun putFile(fileName: String, filePath: String, onProgress: ((Long, Long) -> Unit)? = null)
 
     /**
-     * 上传剪贴板内容（先上传数据文件，再上传配置）
+     * 上传剪贴板内容（先上传数据文件，再上传配置）。
+     *  @param onProgress 文件字节级上传进度（sentBytes, totalBytes），仅文件类型时产生
      */
-    suspend fun putContent(content: ClipboardContent)
+    suspend fun putContent(content: ClipboardContent, onProgress: ((Long, Long) -> Unit)? = null)
 
     /**
      * 查询服务器历史记录（原项目 `POST /api/history/query`）。

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/SyncClipboardHttpClient.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/SyncClipboardHttpClient.kt
@@ -142,26 +142,32 @@ class SyncClipboardHttpClient(
         return destinationPath
     }
 
-    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Float) -> Unit)?) {
+    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Long, Long) -> Unit)?) {
         val file = File(filePath)
         if (!file.exists()) throw IllegalStateException("File not found: $filePath")
 
-        // Upload via multipart or raw bytes depending on server implementation
+        // 分块流式上传：按块读取并上报真实字节进度（onUpload 对 OkHttp 引擎只在结尾回调一次）
+        val total = file.length()
+        val body = CountingFileContent(file, ContentType.Application.OctetStream) { sent ->
+            onProgress?.invoke(sent, total)
+        }
         client.put("$baseUrl$FILE_ENDPOINT${java.net.URLEncoder.encode(fileName, "UTF-8").replace("+", "%20")}") {
             if (username != null && password != null) {
                 header(HttpHeaders.Authorization, buildAuthHeader())
             }
-            // 流式上传：直接以 File 作为 body，避免大文件整体读入内存
-            setBody(file)
+            setBody(body)
         }
     }
 
-    override suspend fun putContent(content: ClipboardContent) {
-        // 如果有文件数据，先上传文件
+    override suspend fun putContent(content: ClipboardContent, onProgress: ((Long, Long) -> Unit)?) {
+        // 如果有文件数据，先上传文件（引擎侧已把 content:// 转为本地临时路径）
         if (content.hasData && content.fileUri != null && content.fileName != null) {
             val name = content.fileName!!
             val uri = content.fileUri!!
-            putFile(name, uri)
+            val fileLen = runCatching { File(uri).length() }.getOrDefault(content.fileSize ?: 0L)
+            onProgress?.invoke(0L, fileLen)
+            putFile(name, uri) { sent, total -> onProgress?.invoke(sent, total) }
+            onProgress?.invoke(fileLen, fileLen)
         }
 
         // 计算 profile hash

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/WebDAVClient.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/api/WebDAVClient.kt
@@ -119,17 +119,22 @@ class WebDAVClient(
         return destinationPath
     }
 
-    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Float) -> Unit)?) {
+    override suspend fun putFile(fileName: String, filePath: String, onProgress: ((Long, Long) -> Unit)?) {
         val file = File(filePath)
         if (!file.exists()) throw IllegalStateException("File not found: $filePath")
 
         // 确保远程目录存在（MKCOL，已存在则忽略 405）
         ensureDataDirectoryExists()
 
+        // 分块流式上传：按块读取并上报真实字节进度
+        val total = file.length()
+        val body = CountingFileContent(file, ContentType.Application.OctetStream) { sent ->
+            onProgress?.invoke(sent, total)
+        }
         val encodedName = URLEncoder.encode(fileName, "UTF-8").replace("+", "%20")
         client.put("$baseUrl/$DATA_DIR/$encodedName") {
             header(HttpHeaders.Authorization, buildAuthHeader())
-            setBody(file.readBytes())
+            setBody(body)
         }
     }
 
@@ -152,11 +157,14 @@ class WebDAVClient(
         }
     }
 
-    override suspend fun putContent(content: ClipboardContent) {
+    override suspend fun putContent(content: ClipboardContent, onProgress: ((Long, Long) -> Unit)?) {
         if (content.hasData && content.fileUri != null && content.fileName != null) {
             val name = content.fileName!!
             val uri = content.fileUri!!
-            putFile(name, uri)
+            val fileLen = runCatching { File(uri).length() }.getOrDefault(content.fileSize ?: 0L)
+            onProgress?.invoke(0L, fileLen)
+            putFile(name, uri) { sent, total -> onProgress?.invoke(sent, total) }
+            onProgress?.invoke(fileLen, fileLen)
         }
 
         val profile = ProfileDto(

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/history/HistoryService.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/history/HistoryService.kt
@@ -31,7 +31,17 @@ class HistoryService(context: Context) {
     companion object {
         private const val TAG = "HistoryService"
         private const val MAX_ITEMS = 1000
+        /** 历史文件磁盘配额（字节）：超过后按最旧优先删除文件并标记对应记录 */
+        private const val MAX_DISK_BYTES = 200L * 1024 * 1024
+        /** 历史文件数量上限 */
+        private const val MAX_DISK_FILES = 400
+        /** enforceDiskLimit 最小执行间隔：避免高频写入时反复全目录扫描 */
+        private const val DISK_LIMIT_INTERVAL_MS = 60_000L
     }
+
+    /** 上次 enforceDiskLimit 执行时间（0 = 从未），批量写入时按间隔节流 */
+    @Volatile
+    private var lastDiskLimitCheck = 0L
 
     private val historyDir = File(context.filesDir, "history_files").apply { if (!exists()) mkdirs() }
 
@@ -106,6 +116,8 @@ class HistoryService(context: Context) {
                     fileUri = fileUri
                 )))
                 trimIfNeeded()
+                // 仅新增了文件才需要检查磁盘配额（文本不占历史目录）
+                if (fileUri != null) enforceDiskLimit()
             }
         }
     }
@@ -140,12 +152,15 @@ class HistoryService(context: Context) {
                     fileUri = downloadPath
                 )))
                 trimIfNeeded()
+                // 仅新增了文件才需要检查磁盘配额（文本不占历史目录）
+                if (downloadPath != null) enforceDiskLimit()
             }
         }
     }
 
     /**
      * 按服务器规则计算内容 hash（与 HashUtils.computeContentHash 对齐，额外支持 content:// URI）。
+     * 分块流式计算，避免大文件整块读入内存。
      */
     private fun computeHashForContent(content: ClipboardContent): String {
         if (content.type == ClipboardContentType.Text || !content.hasData ||
@@ -155,15 +170,16 @@ class HistoryService(context: Context) {
         val fileUri = content.fileUri!!
         val fileName = content.fileName!!
         return try {
-            val bytes: ByteArray? = if (fileUri.startsWith("content://")) {
+            if (fileUri.startsWith("content://")) {
                 val uri = android.net.Uri.parse(fileUri)
-                ctx.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                val input = ctx.contentResolver.openInputStream(uri)
+                if (input != null) HashUtils.computeFileHash(fileName, input)
+                else HashUtils.sha256(content.text)
             } else {
                 val f = java.io.File(fileUri)
-                if (f.exists()) f.readBytes() else null
+                if (f.exists()) HashUtils.computeFileHash(fileName, f)
+                else HashUtils.sha256(content.text)
             }
-            if (bytes != null) HashUtils.computeFileHash(fileName, bytes)
-            else HashUtils.sha256(content.text)
         } catch (e: Exception) {
             Logger.warn(TAG, "computeHashForContent: fallback to text hash: ${e.message}")
             HashUtils.sha256(content.text)
@@ -554,17 +570,28 @@ class HistoryService(context: Context) {
 
     // ─── 内部方法 ────────────────────────────────────────────────
 
-    /** 复制文件到持久化历史目录，返回新文件路径 */
+    /** 复制文件到持久化历史目录，返回新文件路径。
+     *  支持本地路径与 content:// URI（如分享上传时 app FileProvider 授权的 URI）。 */
     private fun copyToHistoryDir(sourceUri: String, fileName: String?, hash: String): String? {
         return try {
-            val src = File(sourceUri)
-            if (!src.exists()) {
-                Logger.warn(TAG, "Source file not exists (may be content:// URI): $sourceUri")
-                return null
-            }
             val name = fileName ?: "file_$hash"
             val dest = File(historyDir, "${hash}_${name}")
-            src.copyTo(dest, overwrite = true)
+            if (sourceUri.startsWith("content://")) {
+                val uri = android.net.Uri.parse(sourceUri)
+                ctx.contentResolver.openInputStream(uri)?.use { input ->
+                    dest.outputStream().use { output -> input.copyTo(output) }
+                } ?: run {
+                    Logger.warn(TAG, "openInputStream returned null for $sourceUri")
+                    return null
+                }
+            } else {
+                val src = File(sourceUri)
+                if (!src.exists()) {
+                    Logger.warn(TAG, "Source file not exists: $sourceUri")
+                    return null
+                }
+                src.copyTo(dest, overwrite = true)
+            }
             Logger.debug(TAG, "Copied to history dir: $sourceUri -> ${dest.absolutePath}")
             dest.absolutePath
         } catch (e: Exception) {
@@ -583,6 +610,55 @@ class HistoryService(context: Context) {
                 dao.softDeleteByIds(ids)
                 Logger.info(TAG, "Trimmed ${ids.size} old items")
             }
+        }
+    }
+
+    /**
+     * 历史文件磁盘配额：总大小/数量超限时，按最后修改时间从旧到新删除文件，
+     * 并软删除对应历史记录（避免 UI 残留"有文件但文件丢失"的空壳）。
+     * 60s 节流：批量推送/同步时不会每条记录都全目录扫描。
+     */
+    fun enforceDiskLimit() {
+        val now = System.currentTimeMillis()
+        synchronized(this) {
+            if (now - lastDiskLimitCheck < DISK_LIMIT_INTERVAL_MS) return
+            lastDiskLimitCheck = now
+        }
+        val files = historyDir.listFiles()?.filter { it.isFile } ?: return
+        var total = files.sumOf { it.length() }
+        var count = files.size
+        if (total <= MAX_DISK_BYTES && count <= MAX_DISK_FILES) return
+        val sorted = files.sortedBy { it.lastModified() }
+        var removed = 0
+        for (file in sorted) {
+            if (total <= MAX_DISK_BYTES && count <= MAX_DISK_FILES) break
+            val hash = file.name.substringBefore('_')
+            // 删除前记录大小：file.delete() 后 length() 返回 0，total 将无法递减
+            val fileLen = file.length()
+            try {
+                val item = dao.getByProfileHash(hash)?.toModel()
+                if (item != null && !item.isDeleted) {
+                    // 与 delete() 一致：已同步记录标记 NeedSync，下次同步推送删除
+                    val newStatus = if (item.syncStatus == HistorySyncStatus.Synced) {
+                        HistorySyncStatus.NeedSync
+                    } else item.syncStatus
+                    dao.upsert(HistoryItemEntity.from(item.copy(
+                        isDeleted = true,
+                        syncStatus = newStatus,
+                        lastModified = System.currentTimeMillis()
+                    )))
+                }
+            } catch (e: Exception) {
+                Logger.warn(TAG, "enforceDiskLimit: failed to mark ${file.name}: ${e.message}")
+            }
+            if (file.delete()) {
+                total -= fileLen
+                count -= 1
+                removed++
+            }
+        }
+        if (removed > 0) {
+            Logger.info(TAG, "enforceDiskLimit: removed $removed file(s), remaining bytes=$total")
         }
     }
 

--- a/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/sync/SyncEngine.kt
+++ b/xposed/src/main/kotlin/io/github/erenche/syncclipboard/xposed/sync/SyncEngine.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.os.PowerManager
 import io.github.erenche.syncclipboard.bridge.BridgeKeys
 import io.github.erenche.syncclipboard.bridge.SyncClipboardBridge
+import io.github.erenche.syncclipboard.common.PackageNames
 import io.github.erenche.syncclipboard.common.Prefs
 import io.github.erenche.syncclipboard.common.model.AppConfig
 import io.github.erenche.syncclipboard.common.model.ClipboardContent
@@ -74,6 +75,16 @@ class SyncEngine private constructor() {
     private var apiClient: SyncClipboardApi? = null
     private var appContext: Context? = null
     private var historyService: HistoryService? = null
+
+    /** 历史服务懒加载：首次真正用到时才初始化（Room DB、目录），
+     *  enableHistorySync=false 的用户不产生任何开销 */
+    @Synchronized
+    private fun getHistoryService(): HistoryService? {
+        if (historyService == null) {
+            appContext?.let { historyService = HistoryService(it) }
+        }
+        return historyService
+    }
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
 
     /** SignalR 推送客户端（仅官方服务器模式创建） */
@@ -148,6 +159,13 @@ class SyncEngine private constructor() {
     /** 历史同步互斥锁，防止并发 syncHistory 调用 */
     private val historySyncMutex = Mutex()
 
+    /** 上次历史增量同步完成时间（基于 elapsedRealtime，不受用户改时间影响） */
+    @Volatile
+    private var lastHistorySyncAt = 0L
+
+    /** SignalR 在线时历史增量同步间隔：推送已实时合并单条，轮询增量仅作兜底 */
+    private val historySyncIntervalSignalRMs = 15 * 60_000L
+
     /** 每次同步最多 PATCH 的记录数。
      *  PATCH 只传元数据（starred/pinned/isDelete/version），无文件上传，单条很轻量；
      *  放宽到 100 以保证批量改动（如 clearAll、批量置顶）能在少数几次同步内推完。 */
@@ -181,7 +199,6 @@ class SyncEngine private constructor() {
         processName = getProcessName(context)
         Logger.info(TAG, "initialize() process=$processName")
 
-        historyService = HistoryService(context)
         config = Prefs.loadConfig(context)
         // 加载持久化的历史同步游标（增量同步用）
         lastSyncTime = Prefs.loadHistoryLastSyncTime(context)
@@ -194,6 +211,9 @@ class SyncEngine private constructor() {
         rebuildApiClient()
         setupBridgeRouting(context)
         registerPowerStateMonitor()
+        // 初始状态检查：省电模式可能在引擎启动前就已开启（广播早已发过，接收器等不到），
+        // 直接评估当前状态，避免 SignalR 在省电模式下持续在线
+        reevaluatePowerSaveState()
         start()
 
         Logger.info(TAG, "SyncEngine initialized, servers=${config.servers.size}, activeIdx=${config.activeServerIndex}")
@@ -220,8 +240,11 @@ class SyncEngine private constructor() {
         // 注册网络监听（移动网络下断开 SignalR / 停止轮询）
         registerNetworkMonitor()
 
-        // 启动 SignalR 推送连接（仅官方服务器模式生效）
-        signalRClient?.start()
+        // 监听本 App 卸载：清理引擎侧数据（历史库/历史文件/下载目录/缓存）
+        registerUninstallMonitor()
+
+        // 启动 SignalR 推送连接（仅官方服务器模式生效；省电/息屏/移动网络暂停时不启动）
+        if (!powerPauseApplied) signalRClient?.start()
 
         // 远程轮询 — 定期从服务器拉取新内容
         scope.launch {
@@ -259,19 +282,20 @@ class SyncEngine private constructor() {
                             Logger.info(TAG, "Polling active")
                             notifySyncStateChanged()
                         }
-                        // 网络可达：顺带重放上传失败队列
-                        appContext?.let { flushUploadQueue(it) }
-                            // 历史增量同步：每轮轮询后尝试增量拉取（tryLock 跳过并发）
-                            // 与 Win 端一致：后台定期增量同步，仅拉 modifiedAfter 之后的记录
-                            // 独立协程执行，避免首次全量同步（游标为 0 时）阻塞剪贴板轮询
-                            // 仅 SyncClipboard 官方服务器模式生效；WebDAV/S3 不支持历史 API
+                            // 历史增量同步：轮询中后台增量拉取（独立协程），手动刷新走 FORCE_SYNC_HISTORY
+                            // SignalR 在线时推送已实时合并单条记录，增量同步降为 15 分钟兜底；
+                            // 离线时保持每轮执行。仅 SyncClipboard 官方服务器模式生效。
                             val server = config.servers.getOrNull(config.activeServerIndex)
                             if (config.enableHistorySync && server?.type == ServerType.syncclipboard) {
-                                scope.launch {
-                                    try {
-                                        syncHistory(force = false)
-                                    } catch (e: Exception) {
-                                        Logger.warn(TAG, "Polling history sync error: ${e.message}")
+                                val sinceLast = android.os.SystemClock.elapsedRealtime() - lastHistorySyncAt
+                                if (!isSignalRConnected || sinceLast >= historySyncIntervalSignalRMs) {
+                                    scope.launch {
+                                        try {
+                                            syncHistory(force = false)
+                                            lastHistorySyncAt = android.os.SystemClock.elapsedRealtime()
+                                        } catch (e: Exception) {
+                                            Logger.warn(TAG, "Polling history sync error: ${e.message}")
+                                        }
                                     }
                                 }
                             }
@@ -290,6 +314,8 @@ class SyncEngine private constructor() {
                     }
                     // 历史同步：轮询中自动增量同步（独立协程），手动刷新走 FORCE_SYNC_HISTORY
                 } else {
+                    // 兜底：省电模式广播丢失/时序遗漏时，由状态循环补齐暂停/恢复
+                    reevaluatePowerSaveState()
                     if (isPollingActive) {
                         isPollingActive = false
                         notifySyncStateChanged()
@@ -399,17 +425,22 @@ class SyncEngine private constructor() {
         }
     }
 
-    /** 省电模式开关：开启且配置断开时暂停，关闭时恢复 */
-    private fun onPowerSaveModeChanged() {
+    /** 省电模式开关广播：重新评估暂停状态 */
+    private fun onPowerSaveModeChanged() = reevaluatePowerSaveState()
+
+    /** 重新评估省电模式暂停状态。
+     *  除广播外，还需在初始启动（省电模式早已开启、广播已错过）、配置变更
+     *  （用户在省电模式已开启时才打开“省电停止”开关）、轮询状态循环（广播
+     *  丢失兜底）时调用，暂停与恢复两种方向都覆盖。 */
+    private fun reevaluatePowerSaveState() {
         if (!isSignalRDisconnectEnabled() && !batterySaverPaused) return
         val pm = appContext?.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return
-        if (pm.isPowerSaveMode) {
-            if (config.stopPollingOnBatterySaver && !batterySaverPaused) {
-                Logger.info(TAG, "Battery saver on, pausing SignalR")
-                batterySaverPaused = true
-                applyPowerPause()
-            }
-        } else if (batterySaverPaused) {
+        val shouldPause = pm.isPowerSaveMode && config.stopPollingOnBatterySaver
+        if (shouldPause && !batterySaverPaused) {
+            Logger.info(TAG, "Battery saver on, pausing SignalR")
+            batterySaverPaused = true
+            applyPowerPause()
+        } else if (batterySaverPaused && (!pm.isPowerSaveMode || !config.stopPollingOnBatterySaver)) {
             Logger.info(TAG, "Battery saver off, resuming SignalR")
             batterySaverPaused = false
             applyPowerPause()
@@ -458,6 +489,11 @@ class SyncEngine private constructor() {
                 as? android.net.ConnectivityManager ?: return
             val callback = object : android.net.ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: android.net.Network) {
+                    // 网络恢复：重放上传失败队列（主要触发点，替代每轮 fetch 成功后的重放）
+                    if (!networkWasAvailable) {
+                        Logger.info(TAG, "Network available, flushing upload queue")
+                        appContext?.let { flushUploadQueue(it) }
+                    }
                     handleNetworkChange(cm)
                 }
                 override fun onLost(network: android.net.Network) {
@@ -481,15 +517,48 @@ class SyncEngine private constructor() {
 
     /** 判断当前活动网络是否为 WiFi，更新移动网络暂停状态 */
     private fun handleNetworkChange(cm: android.net.ConnectivityManager) {
+        val hasNetwork = cm.activeNetwork != null
         val isWifi = cm.activeNetwork?.let { network ->
             cm.getNetworkCapabilities(network)
                 ?.hasTransport(android.net.NetworkCapabilities.TRANSPORT_WIFI) == true
         } ?: false
+        networkWasAvailable = hasNetwork
         val shouldPause = config.disconnectOnMobileData && !isWifi
         if (shouldPause != mobileDataPaused) {
             mobileDataPaused = shouldPause
             Logger.info(TAG, "Network changed: isWifi=$isWifi, mobileDataPaused=$mobileDataPaused")
             applyPowerPause()
+        }
+    }
+
+    // ─── 卸载自清理 ─────────────────────────────────────────────
+
+    /** 卸载监听广播接收器（仅系统发送的 PACKAGE_FULLY_REMOVED，防止第三方伪造触发清理） */
+    private var uninstallReceiver: BroadcastReceiver? = null
+
+    private fun registerUninstallMonitor() {
+        try {
+            val ctx = appContext ?: return
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    // 仅信任系统发出的卸载广播：第三方应用可伪造发送该 action，但不具备 system uid
+                    if (android.os.Binder.getCallingUid() != android.os.Process.SYSTEM_UID) return
+                    if (intent.data?.scheme != "package") return
+                    if (intent.data?.schemeSpecificPart != PackageNames.APPLICATION) return
+                    Logger.info(TAG, "App uninstalled (PACKAGE_FULLY_REMOVED), clearing engine data")
+                    clearEngineData()
+                }
+            }
+            val filter = IntentFilter(Intent.ACTION_PACKAGE_FULLY_REMOVED).apply {
+                addDataScheme("package")
+            }
+            androidx.core.content.ContextCompat.registerReceiver(
+                ctx, receiver, filter, androidx.core.content.ContextCompat.RECEIVER_EXPORTED
+            )
+            uninstallReceiver = receiver
+            Logger.info(TAG, "Uninstall monitor registered")
+        } catch (e: Exception) {
+            Logger.warn(TAG, "Failed to register uninstall monitor: ${e.message}")
         }
     }
 
@@ -541,6 +610,11 @@ class SyncEngine private constructor() {
                 cm?.unregisterNetworkCallback(cb)
             }
             networkCallback = null
+        }
+        // 停止卸载监听
+        uninstallReceiver?.let { receiver ->
+            runCatching { appContext?.unregisterReceiver(receiver) }
+            uninstallReceiver = null
         }
         // 停止 SignalR 连接
         signalRClient?.stop()
@@ -654,7 +728,7 @@ class SyncEngine private constructor() {
         scope.launch {
             try {
                 Logger.debug(TAG, "Local clipboard changed: ${content.text.take(50)}...")
-                historyService?.addLocalContent(content)
+                getHistoryService()?.addLocalContent(content)
                 notifyContentChanged()
                 if (config.enableAutoSync && config.enableBackgroundUpload) {
                     val uploaded = uploadContent(content)
@@ -688,6 +762,8 @@ class SyncEngine private constructor() {
         val oldActiveIdx = config.activeServerIndex
         config = newConfig
         rebuildApiClient()  // 内部会重建 SignalR 客户端
+        // 重新评估省电模式：用户可能在省电模式已开启时才打开“省电停止”开关
+        reevaluatePowerSaveState()
         // 配置变更后重启 SignalR 连接（若已创建且未被息屏/省电暂停）
         if (isRunning && !powerPauseApplied) {
             signalRClient?.start()
@@ -762,7 +838,7 @@ class SyncEngine private constructor() {
      */
     private suspend fun syncHistory(force: Boolean = false, fullSync: Boolean = false): SyncHistoryResult {
         val client = apiClient ?: return SyncHistoryResult(false, 0, "API client is null")
-        val hs = historyService ?: return SyncHistoryResult(false, 0, "History service is null")
+        val hs = getHistoryService() ?: return SyncHistoryResult(false, 0, "History service is null")
         // 互斥锁：防止轮询、FORCE_SYNC_HISTORY、剪贴板变化触发并发 syncHistory
         if (force || fullSync) {
             // 手动触发/全量：等待正在进行的同步完成（最多 15s，防止轮询同步卡住时
@@ -1023,7 +1099,7 @@ class SyncEngine private constructor() {
                 // 手动上传绕过 autoSync/bgUpload 开关，直接上传
                 val hash = content.profileHash ?: HashUtils.sha256(content.text)
                 lastLocalHash = hash
-                historyService?.addLocalContent(content)
+                getHistoryService()?.addLocalContent(content)
                 notifyContentChanged()
                 success = uploadContent(content)
                 // 历史同步改为手动触发，上传后不再自动 syncHistory
@@ -1079,13 +1155,94 @@ class SyncEngine private constructor() {
                     hasData = false,
                     timestamp = System.currentTimeMillis()
                 )
-                historyService?.addLocalContent(content)
+                getHistoryService()?.addLocalContent(content)
                 notifyContentChanged()
                 val ok = uploadContent(content)
                 // 历史同步改为手动触发，上传后不再自动 syncHistory
                 Logger.info(TAG, "uploadText: ok=$ok text=${text.take(20)}")
             } catch (e: Exception) {
                 Logger.error(TAG, "uploadText failed", e)
+            }
+        }
+    }
+
+    /**
+     * App 进程上传文件成功后向引擎登记（分享/主页"上传文件"入口）。
+     *
+     * 引擎负责：按同一份文件计算 hash 写入历史、复制文件到历史目录、
+     * 更新远端缓存（lastRemoteHash/profile），避免轮询把刚上传的内容
+     * 误判为"远端新内容"而重复下载。上传本身已不经过引擎（不再依赖 SystemUI 进程存续）。
+     */
+    fun registerUploadedContent(fileUri: String, fileName: String, isImage: Boolean, fileSize: Long) {
+        if (appContext == null || fileUri.isBlank() || fileName.isBlank()) return
+        scope.launch {
+            try {
+                val ctx = appContext ?: return@launch
+                val type = if (isImage) ClipboardContentType.Image else ClipboardContentType.File
+                // 按与 App 上传时相同的规则计算 hash（分块流式）
+                val hash = try {
+                    val input = ctx.contentResolver.openInputStream(android.net.Uri.parse(fileUri))
+                    if (input != null) HashUtils.computeFileHash(fileName, input)
+                    else HashUtils.sha256(fileName)
+                } catch (e: Exception) {
+                    Logger.warn(TAG, "registerUploadedContent: hash fallback: ${e.message}")
+                    HashUtils.sha256(fileName)
+                }
+                val content = ClipboardContent(
+                    type = type,
+                    text = fileName,
+                    fileUri = fileUri,
+                    fileName = fileName,
+                    fileSize = if (fileSize > 0) fileSize else null,
+                    hasData = true,
+                    profileHash = hash,
+                    timestamp = System.currentTimeMillis()
+                )
+                getHistoryService()?.addLocalContent(content)
+                getHistoryService()?.enforceDiskLimit()
+                lastRemoteHash = hash
+                Prefs.saveLastRemoteHash(ctx, hash)
+                lastRemoteProfile = ProfileDto(
+                    type = type,
+                    hash = hash,
+                    text = fileName,
+                    hasData = true,
+                    dataName = fileName,
+                    size = if (fileSize > 0) fileSize else null
+                )
+                notifyContentChanged()
+                Logger.info(TAG, "registerUploadedContent: hash=${hash.take(12)}, name=$fileName")
+            } catch (e: Exception) {
+                Logger.error(TAG, "registerUploadedContent failed", e)
+            }
+        }
+    }
+
+    /**
+     * 清理引擎本地数据：历史库（软删除+文件）、下载目录、上传临时文件、远端缓存。
+     * 由 App 手动触发（"清理引擎数据"）或 App 卸载时自动触发。
+     */
+    fun clearEngineData() {
+        scope.launch {
+            try {
+                getHistoryService()?.clearAll()
+                appContext?.let { ctx ->
+                    java.io.File(ctx.filesDir, "downloads").let { if (it.exists()) it.deleteRecursively() }
+                    ctx.cacheDir.listFiles()
+                        ?.filter { it.name.startsWith("upload_") }
+                        ?.forEach { it.delete() }
+                    Prefs.saveLastRemoteHash(ctx, null)
+                    Prefs.saveLastRemoteFilePath(ctx, null)
+                }
+                lastSyncTime = 0L
+                appContext?.let { Prefs.resetHistoryLastSyncTime(it) }
+                lastRemoteProfile = null
+                lastRemoteHash = null
+                lastRemoteFilePath = null
+                notifyContentChanged()
+                Logger.info(TAG, "clearEngineData: engine local data cleared")
+            } catch (e: Exception) {
+                Logger.warn(TAG, "clearEngineData failed: ${e.message}")
             }
         }
     }
@@ -1241,9 +1398,14 @@ class SyncEngine private constructor() {
     @Volatile
     private var uploadQueueFlushing = false
 
+    /** 网络是否可用（用于 onAvailable 时判断"恢复"场景，避免重复触发队列重放） */
+    @Volatile
+    private var networkWasAvailable = true
+
     /**
      * 重放上传重试队列：按序重试，成功即出队，失败保留（下次再试）。
-     * 触发时机：新上传成功、轮询 fetch 成功（网络可用信号）、SignalR 重连成功。
+     * 触发时机：入队时、网络恢复（onAvailable）、新上传成功、SignalR 重连成功。
+     * （不再在每轮 fetch 成功后触发，避免高频空检查）
      */
     private fun flushUploadQueue(context: Context) {
         // 队列重放属于后台自动同步行为，总开关关闭时不重放（手动上传不受影响）
@@ -1278,7 +1440,16 @@ class SyncEngine private constructor() {
         }
     }
 
-    private suspend fun uploadContent(content: ClipboardContent): Boolean {
+    /**
+     * 上传剪贴板内容到服务器。
+     *
+     * @param onProgress 字节级上传进度回调（sentBytes, totalBytes），
+     *   totalBytes 未知时为 0；仅文件类型上传时产生。
+     */
+    private suspend fun uploadContent(
+        content: ClipboardContent,
+        onProgress: ((Long, Long) -> Unit)? = null
+    ): Boolean {
         val client = apiClient ?: run {
             Logger.warn(TAG, "No API client configured, skipping upload")
             return false
@@ -1301,7 +1472,7 @@ class SyncEngine private constructor() {
                 content
             }
 
-            client.putContent(uploadContent)
+            client.putContent(uploadContent, onProgress)
             lastSyncTime = System.currentTimeMillis()
             // 设置 lastRemoteHash，防止轮询循环立即下载刚上传的内容
             // 使用 uploadContent（已将 content:// 转为本地路径）保证文件 hash 可读
@@ -1365,6 +1536,13 @@ class SyncEngine private constructor() {
             var downloadedFileUri: android.net.Uri? = null
             var downloadedFilePath: String? = null
             if (profile.hasData && profile.dataName != null) {
+                // 大文件前置拦截：超过自动下载上限（autoDownloadMaxSize）时跳过下载，
+                // 避免 SystemUI 为超大文件耗费流量/IO；内容仍会写剪贴板元数据
+                val size = profile.size ?: 0
+                if (size > config.autoDownloadMaxSize) {
+                    Logger.info(TAG, "downloadAndApplyContent: skip large file ${profile.dataName} " +
+                        "(${size}B > limit ${config.autoDownloadMaxSize}B), keeping clipboard text only")
+                } else {
                 val name = profile.dataName!!
                 val destPath = "${context.filesDir}/downloads/$name"
                 Logger.info(TAG, "downloadAndApplyContent: downloading file $name")
@@ -1373,6 +1551,7 @@ class SyncEngine private constructor() {
                 downloadedFileUri = android.net.Uri.fromFile(destFile)
                 downloadedFilePath = destPath
                 Logger.info(TAG, "File downloaded: $name -> $destPath (size=${destFile.length()})")
+                }
             } else {
                 Logger.debug(TAG, "downloadAndApplyContent: no file data, skipping download")
             }
@@ -1416,7 +1595,7 @@ class SyncEngine private constructor() {
                 profileHash = profile.hash,
                 timestamp = System.currentTimeMillis()
             )
-            historyService?.addRemoteContent(historyContent, downloadedFilePath)
+            getHistoryService()?.addRemoteContent(historyContent, downloadedFilePath)
             Logger.debug(TAG, "downloadAndApplyContent: history recorded")
             lastRemoteFilePath = downloadedFilePath
             appContext?.let { Prefs.saveLastRemoteFilePath(it, downloadedFilePath) }
@@ -1559,7 +1738,10 @@ class SyncEngine private constructor() {
         }
     }
 
-    /** 通知 app 进程手动操作结果（同步/上传） */
+    /**
+     * 通知 app 进程手动操作结果（同步/上传）。
+     * 分享/文件上传已改由 App 进程直接执行，不再经引擎回传。
+     */
     private fun notifyActionResult(action: String, success: Boolean, message: String?) {
         val context = appContext ?: return
         try {
@@ -1670,6 +1852,18 @@ class SyncEngine private constructor() {
                             Logger.warn(TAG, "Catch-up fetch on SignalR reconnect failed: ${e.message}")
                         }
                     }
+                    // 断连期间可能漏掉历史推送：重连后立即补一次历史增量同步
+                    scope.launch {
+                        try {
+                            val server = config.servers.getOrNull(config.activeServerIndex)
+                            if (config.enableHistorySync && server?.type == ServerType.syncclipboard) {
+                                syncHistory(force = false)
+                                lastHistorySyncAt = android.os.SystemClock.elapsedRealtime()
+                            }
+                        } catch (e: Exception) {
+                            Logger.warn(TAG, "Catch-up history sync on reconnect failed: ${e.message}")
+                        }
+                    }
                     // 网络可达：顺带重放上传失败队列
                     appContext?.let { flushUploadQueue(it) }
                 }
@@ -1701,7 +1895,7 @@ class SyncEngine private constructor() {
     /** 处理 SignalR 推送的历史记录变化（增量合并单条 DTO）。
      *  与 syncHistory 互斥，避免全量合并覆盖推送写入的新版本。 */
     private suspend fun handleRemoteHistoryChanged(dto: HistoryRecordDto) {
-        val hs = historyService ?: return
+        val hs = getHistoryService() ?: return
         // 历史推送同步同样受自动同步总开关约束（与轮询路径的历史同步保持一致）
         if (!config.enableAutoSync || !config.enableHistorySync) return
         historySyncMutex.withLock {
@@ -1720,7 +1914,7 @@ class SyncEngine private constructor() {
      *  获取 historySyncMutex 避免与 syncHistory 并发，复用 processPatchItem 逻辑。
      *  仅 SyncClipboard 官方服务器模式生效；WebDAV/S3 不支持历史 PATCH，仅做本地变更。 */
     private suspend fun pushSingleHistoryUpdate(id: String) {
-        val hs = historyService ?: return
+        val hs = getHistoryService() ?: return
         val client = apiClient ?: return
         val server = config.servers.getOrNull(config.activeServerIndex)
         if (server == null || server.type != ServerType.syncclipboard) return
@@ -1804,9 +1998,48 @@ class SyncEngine private constructor() {
                 uploadText(text)
             }
 
+            onCommand(BridgeKeys.REGISTER_UPLOADED) { data ->
+                val fileUri = data.getString("fileUri") ?: return@onCommand
+                val fileName = data.getString("fileName") ?: return@onCommand
+                val isImage = data.getBoolean("isImage", false)
+                val fileSize = data.getLong("fileSize", 0L)
+                registerUploadedContent(fileUri, fileName, isImage, fileSize)
+            }
+
+            onCommand(BridgeKeys.CLEAR_ENGINE_DATA) {
+                clearEngineData()
+            }
+
+            onQuery(BridgeKeys.GET_DOWNLOADED_FILE) {
+                // 查询引擎下载目录中已存在的文件，命中则直接返回字节（≤2MB），
+                // app 端预览免走一次网络下载。Binder 事务限制约 1MB，留余量。
+                val fileName = data.getString("fileName")
+                if (fileName.isNullOrBlank()) {
+                    reply(Bundle.EMPTY)
+                    return@onQuery
+                }
+                try {
+                    val ctx = appContext
+                    if (ctx != null) {
+                        val file = java.io.File(java.io.File(ctx.filesDir, "downloads"), fileName)
+                        if (file.isFile && file.length() in 1..2_000_000L) {
+                            reply(Bundle().apply {
+                                putByteArray("bytes", file.readBytes())
+                                putLong("size", file.length())
+                            })
+                            return@onQuery
+                        }
+                    }
+                    reply(Bundle.EMPTY)
+                } catch (e: Exception) {
+                    Logger.warn(TAG, "GET_DOWNLOADED_FILE failed: ${e.message}")
+                    reply(Bundle.EMPTY)
+                }
+            }
+
             onQuery(BridgeKeys.GET_HISTORY) {
-                val items = historyService?.getAll() ?: emptyList()
-                Logger.info(TAG, "GET_HISTORY: historyService=${if (historyService != null) "exists" else "null"}, items=${items.size}")
+                val items = getHistoryService()?.getAll() ?: emptyList()
+                Logger.info(TAG, "GET_HISTORY: items=${items.size}")
                 val itemsJson = Json.encodeToString(
                     ListSerializer(HistoryItem.serializer()), items
                 )
@@ -1818,7 +2051,7 @@ class SyncEngine private constructor() {
                 val offset = data.getInt("offset", 0)
                 val limit = data.getInt("limit", 50)
                 val searchText = data.getString("searchText")
-                val hs = historyService
+                val hs = getHistoryService()
                 if (hs != null) {
                     val pageItems = hs.getPaged(offset, limit, searchText)
                     val totalCount = hs.count(searchText)
@@ -1845,7 +2078,7 @@ class SyncEngine private constructor() {
                     reply(Bundle().apply { putBoolean("started", true) })
                     scope.launch {
                         val result = syncHistory(force = true, fullSync = false)
-                        val localCount = historyService?.getAll()?.size ?: 0
+                        val localCount = getHistoryService()?.getAll()?.size ?: 0
                         Logger.info(TAG, "FORCE_SYNC_HISTORY: success=${result.success}, fetched=${result.recordsFetched}, local=$localCount, error=${result.error}")
                         notifyHistorySyncCompleted(result.success, result.recordsFetched, localCount, result.error)
                     }
@@ -1860,14 +2093,14 @@ class SyncEngine private constructor() {
 
             onCommand(BridgeKeys.DELETE_HISTORY_ITEM) { data ->
                 val id = data.getString("id") ?: return@onCommand
-                historyService?.delete(id)
+                getHistoryService()?.delete(id)
                 Logger.info(TAG, "History item deleted: $id")
             }
 
             onCommand(BridgeKeys.UPDATE_HISTORY_ITEM) { data ->
                 val id = data.getString("id") ?: return@onCommand
                 val action = data.getString("action") ?: "toggleStar"
-                val hs = historyService ?: return@onCommand
+                val hs = getHistoryService() ?: return@onCommand
                 when (action) {
                     "toggleStar" -> {
                         hs.toggleStar(id)
@@ -1883,7 +2116,7 @@ class SyncEngine private constructor() {
             }
 
             onCommand(BridgeKeys.CLEAR_HISTORY) {
-                historyService?.clearAll()
+                getHistoryService()?.clearAll()
                 // 重置历史同步游标，强制下次全量同步
                 // 这样 mergeFromServerDtos 会从服务器恢复活跃记录
                 lastSyncTime = 0L


### PR DESCRIPTION
- 新增 ShareActivity：接收系统分享的文本/文件并上传到服务器， 上传进度展示、超时与异常处理（CancellationException 正确传播）
- 历史文件磁盘配额（LRU 清理 + 60s 节流），修复删除后 total 计算错误
- SignalR 在线时历史增量同步降频为 15 分钟兜底
- HistoryService 懒加载，enableHistorySync=false 零开销
- 上传重试队列重放收敛（仅入队/网络恢复/上传成功/重连时触发）
- 大文件前置拦截：超过 autoDownloadMaxSize 跳过下载仅保留元数据
- 下载与预览去重：新增 GET_DOWNLOADED_FILE 查询，app 优先复用引擎已下载文件
- 修复省电模式停止连接不生效：初始启动/配置变更/轮询循环均重新评估省电状态